### PR TITLE
Fix tailwind install on Vercel

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,13 +28,13 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^4.1.11",
     "zod": "^4.0.5"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "prisma": "^6.11.1",
-    "tailwindcss": "^4.1.11",
     "typescript": "5.8.3"
   }
 }


### PR DESCRIPTION
## Summary
- ensure Tailwind CSS installs during Vercel production builds

## Testing
- `npm run build` *(fails: prisma not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cdde2ab708328bdd8f7c8d03f8237